### PR TITLE
If logs is undefined, create it

### DIFF
--- a/click-to-proceed/click-to-proceed.js
+++ b/click-to-proceed/click-to-proceed.js
@@ -19,7 +19,7 @@
 		}
 		
 		get log() {
-			const logs = variables()["@CTP/Logs"];
+			const logs = variables()["@CTP/Logs"] || new Map();
 			if (!logs.get(this.id)) logs.set(this.id, { lastClear: -1, index: -1, seen: -1 });
 			return logs.get(this.id);
 		}


### PR DESCRIPTION
- If you click the history back button on an old save, `logs` may not exist in the state yet; this can create an error as CTP will try to use a `logs` that doesn't exist.